### PR TITLE
Prisma centrilization

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,8 @@
-import session from "express-session";
+import session from 'express-session';
+import { User } from '@prisma/client';
 
-declare module "express-session" {
+declare module 'express-session' {
   interface SessionData {
-    username: string;
+    user: User
   }
 }

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -1,28 +1,32 @@
-import { PrismaClient, Prisma, Role } from '@prisma/client';
+import { Prisma, Role } from '@prisma/client';
+import { prisma } from '../prisma';
 import bcrypt from 'bcrypt';
 import type { AuthPayload, ChangeUserPasswordInput, Response, CreateUserMutationResult} from '../schema/graphql';
+// import type { Context } from '../context';
 
 // User with username testuser and password testpassword
 // username: 'testuser',
 // password: '$2b$10$ogZBif.TabQ/LoAk8LjlG./hNq3tsWBE9OAzbc.dY/hQdYMIPhBly',
-
-const prisma = new PrismaClient();
+// const prisma = new PrismaClient();
 
 export async function login(username: string, password: string): Promise<AuthPayload> {
   const user = await lookupUser(username);
-
+  const users = await prisma.user.findMany();
+  console.log(users);
   const failedAuth = {
     message: 'Incorrect username or password',
     success: false,
     token: '', // Won't be needed anymore
   };
 
+  console.log(user);
   if (user === null) return failedAuth;
 
 
   const valid = await bcrypt.compare(password, user!.password);
 
   if (!valid) {
+    // ctx.session.username = username;
     return {
       message: 'Incorrect username or password',
       success: false,
@@ -103,6 +107,7 @@ export async function isAdmin(username: string): Promise<boolean> {
 }
 
 async function lookupUser(username: string) {
+  console.log(username);
   const user = await prisma.user.findUnique({
     where: {
       username: username,

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -1,18 +1,12 @@
-import { Request } from "express";
-import { Session, SessionData } from "express-session";
-import { PrismaClient, Prisma, Role } from '@prisma/client';
-import type { AuthPayload } from '../schema/graphql'
-import { login } from '../auth'
+import { Request } from 'express';
+import { Session, SessionData } from 'express-session';
 
-const prisma = new PrismaClient();
 
 export interface Context {
   // TODO: keep here until we have login implemented. a partial given it could be undefined
   session: Session & Partial<SessionData>;
   // TODO: add context (aka. prisma, auth, etc.)
-  prisma: PrismaClient;
   logout: () => Promise<void>;
-  login: (username: string, password: string) => Promise<AuthPayload>;
 }
 
 export async function createContext({
@@ -25,8 +19,6 @@ export async function createContext({
   const { session } = req;
   return {
     session,
-    prisma,
-    login: login,
     logout: async () => new Promise((resolve) => session.destroy(resolve)),
   };
 }

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -1,11 +1,18 @@
 import { Request } from "express";
 import { Session, SessionData } from "express-session";
+import { PrismaClient, Prisma, Role } from '@prisma/client';
+import type { AuthPayload } from '../schema/graphql'
+import { login } from '../auth'
+
+const prisma = new PrismaClient();
 
 export interface Context {
   // TODO: keep here until we have login implemented. a partial given it could be undefined
   session: Session & Partial<SessionData>;
   // TODO: add context (aka. prisma, auth, etc.)
+  prisma: PrismaClient;
   logout: () => Promise<void>;
+  login: (username: string, password: string) => Promise<AuthPayload>;
 }
 
 export async function createContext({
@@ -18,6 +25,8 @@ export async function createContext({
   const { session } = req;
   return {
     session,
+    prisma,
+    login: login,
     logout: async () => new Promise((resolve) => session.destroy(resolve)),
   };
 }

--- a/src/prisma/index.ts
+++ b/src/prisma/index.ts
@@ -1,0 +1,4 @@
+import { PrismaClient } from '@prisma/client';
+export { prisma };
+
+const prisma = new PrismaClient();

--- a/src/prisma/index.ts
+++ b/src/prisma/index.ts
@@ -1,4 +1,15 @@
 import { PrismaClient } from '@prisma/client';
-export { prisma };
+export { prisma, lookupUser };
 
 const prisma = new PrismaClient();
+
+async function lookupUser(username: string) {
+  console.log(`looking up ${username}`);
+  const user = await prisma.user.findUnique({
+    where: {
+      username: username,
+    },
+  });
+  console.log(user);
+  return user;
+}

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -31,13 +31,15 @@ export const resolvers: Resolvers<Context> = {
     login: async (_, params, ctx) => {
       if (ctx.session.username) return alreadyLoggedIn;
 
-      const loginResult: AuthPayload = await login(params.username, params.password);
+      //const loginResult: AuthPayload = await login(params.username, params.password, ctx);
 
-      if (loginResult.success) {
-        // set user in session
-        ctx.session.username = params.username;
-      }
-      return loginResult;
+     // if (loginResult.success) {
+     //   // set user in session
+     //   ctx.session.username = params.username;
+     // }
+     // return loginResult;
+
+      return await ctx.login(params.username, params.password);
     },
     logout: async (_, _params, ctx) => {
       if (!ctx.session.username) return noLogin;

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -1,7 +1,7 @@
 import { Context } from '../context';
 import { Resolvers } from '../schema';
-import type { AuthPayload } from '../schema';
-import { login, createNewUser, changePassword, isAdmin } from '../auth';
+import { login, createNewUser, changePassword } from '../auth';
+import * as utils from '../utils';
 
 const noLogin = {
   success: false,
@@ -20,29 +20,22 @@ const noPerms = {
   success: false,
 };
 
+
 export const resolvers: Resolvers<Context> = {
   Query: {
     me: (_, _params, ctx) => {
-      console.log(ctx.session.username);
+      if (!ctx.session.user) return null;
+      console.log(ctx.session.user.username);
       return null;
     },
   },
   Mutation: {
     login: async (_, params, ctx) => {
-      if (ctx.session.username) return alreadyLoggedIn;
-
-      //const loginResult: AuthPayload = await login(params.username, params.password, ctx);
-
-     // if (loginResult.success) {
-     //   // set user in session
-     //   ctx.session.username = params.username;
-     // }
-     // return loginResult;
-
-      return await ctx.login(params.username, params.password);
+      if (ctx.session.user) return alreadyLoggedIn;
+      else return await login(params.username, params.password, ctx);
     },
     logout: async (_, _params, ctx) => {
-      if (!ctx.session.username) return noLogin;
+      if (!ctx.session.user) return noLogin;
       else {
         await ctx.logout();
         return {
@@ -53,12 +46,12 @@ export const resolvers: Resolvers<Context> = {
       };
     },
     changeUserPassword: async (_, _params, ctx) => {
-      if (!ctx.session.username) return noLogin;
-      else return changePassword(ctx.session.username, _params.input);
+      if (!ctx.session.user) return noLogin;
+      else return changePassword(ctx.session.user, _params.input);
     },
     createUser: async (_, _params, ctx) => {
-      if (!ctx.session.username) return noLogin;
-      else if (! await isAdmin(ctx.session.username)) return noPerms;
+      if (!ctx.session.user) return noLogin;
+      else if (! await utils.isAdmin(ctx.session.user)) return noPerms;
       else return await createNewUser(_params.username);
     },
   },

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,3 @@
+import { User, Role } from '@prisma/client';
+
+export const isAdmin = (user: User) => user.role === Role.ADMIN;


### PR DESCRIPTION
Pasted from e18beeeed9b4818a50bc86ecb7bb0fee803a88c3 


    Put prisma in a central location

    Prisma has been given its own 'module'. To use it, import it in your
    module with:

        import { prisma } from '../prisma'

    Then you can make any calls with the prisma client.

    Some other refactoring for authentication and session data is included
    in this commit. The session now holds a prisma User object, which can
    be easily passed on to any resolvers without having to make more database
    lookups.

    It should be noted that whenever a database update to the user who is
    logged in is made, the user must log out for changes to take effect.
