### PR TITLE
fix: Dockerfile w/Prisma and added GitHub Action for building container image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+tests
+db-data

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+Dockerfile @aomi

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,23 @@
+name: Docker
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      # - name: Login to DockerHub
+      #   uses: docker/login-action@v2
+      #   with:
+      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
+      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          push: false
+          tags: seng499c3/backend:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,13 +14,20 @@ RUN npm run build
 FROM node:16-alpine as runner
 # Set NODE_ENV to production
 ENV NODE_ENV production
+ENV CI true
 WORKDIR /usr/src/app
 # Copy built application to runner
 COPY --chown=node:node --from=builder /usr/src/app/build ./build
 # Copy dependencies to runner
 COPY package*.json ./
 # Install production (omit devDepencies)
-RUN npm ci --no-audit --quiet --omit=dev && npm cache clean --force --quiet
+RUN npm ci --no-audit --quiet --omit=dev && npm cache clean --force --quiet \ 
+    && rm ./node_modules/@prisma/engines/migration-engine-* \ 
+    ./node_modules/@prisma/engines/introspection-engine-* \
+    && rm -rf /root/.cache/prisma
+# In theory, the introspection and migration engine are not required for production.
+# This is why they are deleted. This also means this container only works in a production-like setting.
+# This cursed solution shaves 100MB or so which is nice...
 # Copy Prisma Client to runner
 COPY --chown=node:node --from=builder /usr/src/app/node_modules/.prisma ./node_modules/.prisma
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,28 @@
-FROM node:16-alpine
+FROM node:16-alpine as builder
 
 WORKDIR /usr/src/app
 
 # Install app dependencies
-COPY package*.json /usr/src/app/
-RUN npm install
-
-COPY . /usr/src/app
-
+COPY package*.json prisma ./
+RUN npm ci --no-audit --quiet 
+# Copy application
+COPY . .
+# Build Application
 RUN npm run build
+
+# Configure runner
+FROM node:16-alpine as runner
+# Set NODE_ENV to production
+ENV NODE_ENV production
+WORKDIR /usr/src/app
+# Copy built application to runner
+COPY --chown=node:node --from=builder /usr/src/app/build ./build
+# Copy dependencies to runner
+COPY package*.json ./
+# Install production (omit devDepencies)
+RUN npm ci --no-audit --quiet --omit=dev && npm cache clean --force --quiet
+# Copy Prisma Client to runner
+COPY --chown=node:node --from=builder /usr/src/app/node_modules/.prisma ./node_modules/.prisma
 
 CMD ["npm", "start"]
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # backend
 
+## Development
+Make sure you run `npm ci` and `npm run setup` frequently. If you switch branches and dependencies change you must run `npm ci` to make sure your dependencies are up to date. `npm run setup` will update the Prisma files and setup Husky. Make sure you run these frequently as well to make sure you're running on the latest changes. 
+
 ## Apollo Studio
 
 In order to have cookies work within Apollo Studio during development, please make sure your Apollo Studio configuration matches the following:

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,10 +7,9 @@
     "": {
       "name": "backend",
       "version": "1.0.0",
-      "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
-        "@prisma/client": "^3.14.0",
+        "@prisma/client": "^3.15.2",
         "apollo-server-core": "^3.8.1",
         "apollo-server-express": "^3.8.1",
         "bcrypt": "^5.0.1",
@@ -35,7 +34,7 @@
         "husky": "^8.0.1",
         "jest": "^28.1.0",
         "prettier": "^2.7.0",
-        "prisma": "^3.15.1",
+        "prisma": "^3.15.2",
         "supertest": "^6.2.3",
         "ts-jest": "^28.0.3",
         "ts-node-dev": "^2.0.0",
@@ -2612,9 +2611,9 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-3.15.1.tgz",
-      "integrity": "sha512-Lsk7oupvO9g99mrIs07iE6BIMouHs46Yq/YY8itTsUQNKfecsPuZvVYvcKci0pqRQ0neOpvIvoA/ouZmIMBCrQ==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-3.15.2.tgz",
+      "integrity": "sha512-ErqtwhX12ubPhU4d++30uFY/rPcyvjk+mdifaZO5SeM21zS3t4jQrscy8+6IyB0GIYshl5ldTq6JSBo1d63i8w==",
       "hasInstallScript": true,
       "dependencies": {
         "@prisma/engines-version": "3.15.1-1.461d6a05159055555eb7dfb337c9fb271cbd4d7e"
@@ -9502,9 +9501,9 @@
       }
     },
     "node_modules/prisma": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-3.15.1.tgz",
-      "integrity": "sha512-MLO3JUGJpe5+EVisA/i47+zlyF8Ug0ivvGYG4B9oSXQcPiUHB1ccmnpxqR7o0Up5SQgmxkBiEU//HgR6UuIKOw==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-3.15.2.tgz",
+      "integrity": "sha512-nMNSMZvtwrvoEQ/mui8L/aiCLZRCj5t6L3yujKpcDhIPk7garp8tL4nMx2+oYsN0FWBacevJhazfXAbV1kfBzA==",
       "devOptional": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -13206,9 +13205,9 @@
       }
     },
     "@prisma/client": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-3.15.1.tgz",
-      "integrity": "sha512-Lsk7oupvO9g99mrIs07iE6BIMouHs46Yq/YY8itTsUQNKfecsPuZvVYvcKci0pqRQ0neOpvIvoA/ouZmIMBCrQ==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-3.15.2.tgz",
+      "integrity": "sha512-ErqtwhX12ubPhU4d++30uFY/rPcyvjk+mdifaZO5SeM21zS3t4jQrscy8+6IyB0GIYshl5ldTq6JSBo1d63i8w==",
       "requires": {
         "@prisma/engines-version": "3.15.1-1.461d6a05159055555eb7dfb337c9fb271cbd4d7e"
       }
@@ -18474,9 +18473,9 @@
       }
     },
     "prisma": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-3.15.1.tgz",
-      "integrity": "sha512-MLO3JUGJpe5+EVisA/i47+zlyF8Ug0ivvGYG4B9oSXQcPiUHB1ccmnpxqR7o0Up5SQgmxkBiEU//HgR6UuIKOw==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-3.15.2.tgz",
+      "integrity": "sha512-nMNSMZvtwrvoEQ/mui8L/aiCLZRCj5t6L3yujKpcDhIPk7garp8tL4nMx2+oYsN0FWBacevJhazfXAbV1kfBzA==",
       "devOptional": true,
       "requires": {
         "@prisma/engines": "3.15.1-1.461d6a05159055555eb7dfb337c9fb271cbd4d7e"

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "db:generate": "prisma generate",
     "db:migrate": "prisma migrate dev",
     "db:seed": "prisma db seed",
-    "postinstall": "npm run db:generate",
-    "prepare": "husky install"
+    "setup": "husky install && npm run db:generate"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/package.json
+++ b/package.json
@@ -47,14 +47,14 @@
     "husky": "^8.0.1",
     "jest": "^28.1.0",
     "prettier": "^2.7.0",
-    "prisma": "^3.15.1",
+    "prisma": "^3.15.2",
     "supertest": "^6.2.3",
     "ts-jest": "^28.0.3",
     "ts-node-dev": "^2.0.0",
     "typescript": "^4.7.2"
   },
   "dependencies": {
-    "@prisma/client": "^3.14.0",
+    "@prisma/client": "^3.15.2",
     "apollo-server-core": "^3.8.1",
     "apollo-server-express": "^3.8.1",
     "bcrypt": "^5.0.1",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,6 +3,7 @@
 
 generator client {
   provider = "prisma-client-js"
+  binaryTargets= "native"
 }
 
 datasource db {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "ES2020",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "ES2020" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
@@ -25,7 +25,7 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "commonjs",                                /* Specify what module code is generated. */
+    "module": "commonjs" /* Specify what module code is generated. */,
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
     // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
@@ -49,7 +49,7 @@
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    "outDir": "./build",                                   /* Specify an output folder for all emitted files. */
+    "outDir": "./build" /* Specify an output folder for all emitted files. */,
     // "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
@@ -71,12 +71,12 @@
     /* Interop Constraints */
     // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
     // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
-    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
-    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+    "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
 
     /* Type Checking */
-    "strict": true,                                      /* Enable all strict type-checking options. */
+    "strict": true /* Enable all strict type-checking options. */,
     // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
     // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
@@ -98,6 +98,8 @@
 
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
-  }
+    "skipLibCheck": true /* Skip type checking all .d.ts files. */
+  },
+  "include": ["src/**/*.ts", "prisma/**/*.ts", "tests/**/*.ts", "**/*.d.ts"],
+  "exclude": ["node_modules", ".vscode"]
 }


### PR DESCRIPTION
Closes #45 
This PR updates the Dockerfile to build the image in a multi-stage process. Also, the Docker stage is added to build the image.

Some notable changes are the removal of the `prepare` script. This means that Husky must be setup manually by the developer. The Prisma generate does also not run automatically post install anymore. These changes were made due to the Dockerfile needing access to them for native binaries but not desired within its build stages.

The Dockerfile does some steps to remove some unused binaries from Prisma manually. This helps shave a significant amount of size from the built image.

Note from ARM users, this won't work on ARM64 (me...) due to some issues with Prisma however I think for everyone else this image will work.