### PR TITLE
Ignore the db-data folder when linting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,5 +17,5 @@
     "max-len": "off",
     "prettier/prettier": ["error"]
   },
-  "ignorePatterns": ["*.d.ts", "node_modules", "build", "src/schema/graphql.ts", "src/client"]
+  "ignorePatterns": ["*.d.ts", "node_modules", "build", "src/schema/graphql.ts", "src/client", "db-data"]
 }


### PR DESCRIPTION
Very minor fix.

On my machine prisma locks down this folder so that eslint gets permission denied when trying to access it, leading to failing lint every time I restart the application.

