### PR TITLE
Add description for topics course

### DIFF
--- a/prisma/migrations/20220707024006_add_topic_description_for_informaiton_about_a_topics_course_a_professor_might_want_to_teach/migration.sql
+++ b/prisma/migrations/20220707024006_add_topic_description_for_informaiton_about_a_topics_course_a_professor_might_want_to_teach/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "TeachingPreference" ADD COLUMN     "topicDescription" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -71,6 +71,7 @@ model TeachingPreference {
   studyLeave         Boolean
   studyLeaveReason   String?
   topicsOrGradCourse Boolean
+  topicDescription   String?
   User               User?              @relation(fields: [userId], references: [id])
   userId             Int?               @unique
 


### PR DESCRIPTION
The topicDescription column has been added to the teaching preference model.

This was needed because when a professor wants to teach a topics course, they also need to provide some information on the course. That information will be stored in topicDescription.