### PR TITLE
feat: teacher preferences query and mutation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,8 @@
 import session from 'express-session';
-import { User } from '@prisma/client';
+import { FullUser } from './src/resolvers/resolverUtils';
 
 declare module 'express-session' {
   interface SessionData {
-    user: User;
+    user: FullUser;
   }
 }

--- a/src/prisma/user.ts
+++ b/src/prisma/user.ts
@@ -1,10 +1,20 @@
+import { CreateTeachingPreferenceInput } from '../schema';
 import { prisma } from './index';
-export { findUserByUsername, findUserById, findAllUsers };
+export { findUserByUsername, findUserById, findAllUsers, updateUserSurvey };
 
 async function findUserByUsername(username: string) {
   const user = await prisma.user.findUnique({
     where: {
       username: username,
+    },
+    include: {
+      preference: {
+        include: {
+          coursePreference: {
+            include: { course: true },
+          },
+        },
+      },
     },
   });
   return user;
@@ -13,11 +23,76 @@ async function findUserByUsername(username: string) {
 async function findUserById(userid: number) {
   const finduser = await prisma.user.findUnique({
     where: { id: userid },
+    include: {
+      preference: {
+        include: {
+          coursePreference: {
+            include: { course: true },
+          },
+        },
+      },
+    },
   });
   return finduser;
 }
 
 async function findAllUsers() {
-  const allusers = await prisma.user.findMany();
+  const allusers = await prisma.user.findMany({
+    include: {
+      preference: {
+        include: {
+          coursePreference: {
+            include: { course: true },
+          },
+        },
+      },
+    },
+  });
   return allusers;
+}
+
+async function updateUserSurvey(
+  id: number,
+  input: CreateTeachingPreferenceInput
+) {
+  const preferenceUpdateBody = {
+    coursePreference: {
+      create: input.courses.map((c) => {
+        return {
+          preference: c.preference,
+          course: {
+            connect: {
+              subject_courseCode_term: {
+                subject: c.subject,
+                courseCode: c.code,
+                term: c.term,
+              },
+            },
+          },
+        };
+      }),
+    },
+    nonTeachingTerm1: input.nonTeachingTerm,
+    hasRelief: input.hasRelief,
+    reliefReason: input.reliefReason,
+    studyLeave: false,
+    topicsOrGradCourse: input.hasTopic,
+  };
+
+  await prisma.user.update({
+    where: {
+      id: id,
+    },
+    data: {
+      preference: {
+        upsert: {
+          where: {
+            userId: id,
+          },
+          update: preferenceUpdateBody,
+          create: preferenceUpdateBody,
+        },
+      },
+    },
+  });
 }

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -119,7 +119,7 @@ export const resolvers: Resolvers<Context> = {
       return {
         token: '',
         success: true,
-        message: 'update prefs',
+        message: 'Teaching preferences updated.',
       };
     },
     generateSchedule: async (_, { input }, ctx) => {

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -63,14 +63,18 @@ export const resolvers: Resolvers<Context> = {
     },
     survey: async (_, __, ctx) => {
       if (!ctx.session.user) return { courses: [] };
-      const fallCourses = (await getCourses(Term.Fall)) ?? [];
-      const springCourses = (await getCourses(Term.Spring)) ?? [];
-      const summerCourses = (await getCourses(Term.Summer)) ?? [];
+      const courses = (
+        await Promise.all([
+          getCourses(Term.Fall),
+          getCourses(Term.Spring),
+          getCourses(Term.Summer),
+        ])
+      )
+        .flatMap((p) => p ?? [])
+        .map((c) => c.CourseID);
 
       return {
-        courses: [...fallCourses, ...springCourses, ...summerCourses].map(
-          (c) => c.CourseID
-        ),
+        courses,
       };
     },
     courses: async (_, params, ctx) => {


### PR DESCRIPTION
* implemented `survey` query to retrieve a list of courses that the professor can submit a preference for
* Implemented the `createTeachingPreference` mutation for a professor to submit their survey
* Joined the teacher survey in when fetching a user so their preferences show up in the GraphQL results now

Currently there is a limitation with the db implementation where if two professors submit the same course and preference ("PHYS 110 Fall with preference 1", for example) the upsert will fail. Honestly this problem is so complicated that it would take a paragraph of typing to explain in the PR so just ask on discord voice if you need an explanation