### PR TITLE
Change repository dispatch event name for E2E tests

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -48,5 +48,5 @@ jobs:
         with:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
           repository: seng499-s22-company3/shared
-          event-type: backend
+          event-type: company3-backend
           client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "repo": "backend"}'


### PR DESCRIPTION
Change event name to reduce ambiguity in E2E tests between company 3 and 4.