### PR TITLE
Retrieve sectionNumber

### DIFF
--- a/src/resolvers/resolverUtils.ts
+++ b/src/resolvers/resolverUtils.ts
@@ -170,6 +170,7 @@ async function getSchedule(year: number): Promise<Schedule | null> {
         },
         capacity: course.capacity,
         hoursPerWeek: course.hoursPerWeek,
+        sectionNumber: course.sectionNumber,
         startDate: course.startDate,
         endDate: course.endDate,
         meetingTimes: course.meetingTime.flatMap<MeetingTime>((meetingTime) => {


### PR DESCRIPTION
Added `sectionNumber` field in `getSchedule` to get non null value when generating schedule.
Fixes the issue of returning null for `sectionNumber` field in Frontend.