### PR TITLE
feat: pass in default pref values for prof terms

### DIFF
--- a/src/resolvers/resolverUtils.ts
+++ b/src/resolvers/resolverUtils.ts
@@ -317,6 +317,9 @@ async function generateScheduleWithCapacities(
       users?.map((user) => {
         return {
           displayName: user.displayName ?? '',
+          falltermCourses: 1,
+          springtermCourses: 1,
+          summertermCourses: 1,
           preferences:
             user.preferences?.map((preference) => {
               return {
@@ -327,7 +330,7 @@ async function generateScheduleWithCapacities(
             }) ?? [],
         };
       }) ?? []
-    ).filter((p) => p.preferences.length > 0) as any,
+    ).filter((p) => p.preferences.length > 0),
   };
 
   const alg1 = ctx.algorithm(input.algorithm1).algo1;


### PR DESCRIPTION
Context: https://uvic2022summerseng499.slack.com/archives/C03ER8VUA67/p1657657856237399?thread_ts=1657653286.913609&cid=C03ER8VUA67
This PR adds default values so it works with algorithm 1 on company 4. This isn't a required value hence why we never passed one in.