### PR TITLE
Add updateSchedule to GraphQL schema

### DIFF
--- a/codegen.yml
+++ b/codegen.yml
@@ -1,8 +1,8 @@
 overwrite: true
-schema: "src/schema/schema.graphql"
+schema: 'src/schema/schema.graphql'
 documents: null
 generates:
-  schema/graphql.ts:
+  src/schema/graphql.ts:
     plugins:
-      - "typescript"
-      - "typescript-resolvers"
+      - 'typescript'
+      - 'typescript-resolvers'

--- a/src/schema/graphql.ts
+++ b/src/schema/graphql.ts
@@ -1,22 +1,10 @@
-import {
-  GraphQLResolveInfo,
-  GraphQLScalarType,
-  GraphQLScalarTypeConfig,
-} from 'graphql';
+import { GraphQLResolveInfo, GraphQLScalarType, GraphQLScalarTypeConfig } from 'graphql';
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
-export type Exact<T extends { [key: string]: unknown }> = {
-  [K in keyof T]: T[K];
-};
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
-  [SubKey in K]?: Maybe<T[SubKey]>;
-};
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
-  [SubKey in K]: Maybe<T[SubKey]>;
-};
-export type RequireFields<T, K extends keyof T> = Omit<T, K> & {
-  [P in K]-?: NonNullable<T[P]>;
-};
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+export type RequireFields<T, K extends keyof T> = Omit<T, K> & { [P in K]-?: NonNullable<T[P]> };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -34,10 +22,7 @@ export type AuthPayload = {
   message?: Maybe<Scalars['String']>;
   /** Whether auth operation was successful or not */
   success: Scalars['Boolean'];
-  /**
-   * Auth token used for future requests
-   * @deprecated Field no longer supported
-   */
+  /** Auth token used for future requests */
   token: Scalars['String'];
 };
 
@@ -49,7 +34,7 @@ export type ChangeUserPasswordInput = {
 /** Company 3 and 4 */
 export enum Company {
   Company3 = 'COMPANY3',
-  Company4 = 'COMPANY4',
+  Company4 = 'COMPANY4'
 }
 
 export type CourseId = {
@@ -110,6 +95,36 @@ export type CourseSection = {
   startDate: Scalars['Date'];
 };
 
+export type CourseSectionInput = {
+  /** Maximum capacity of the section */
+  capacity: Scalars['Int'];
+  /** The end date of the course */
+  endDate: Scalars['Date'];
+  /** How many hours per week a course takes */
+  hoursPerWeek: Scalars['Float'];
+  /** The course identifier */
+  id: CourseUpdateInput;
+  /** Days of the week the class is offered in - see Day */
+  meetingTimes: Array<MeetingTimeInput>;
+  /** Professor's info, if any professors are assigned. Usernames */
+  professors: Array<Scalars['String']>;
+  /** Section number for courses, eg: A01, A02 */
+  sectionNumber?: InputMaybe<Scalars['String']>;
+  /** The start date of the course */
+  startDate: Scalars['Date'];
+};
+
+export type CourseUpdateInput = {
+  /** Course code, e.g. 499, 310 */
+  code: Scalars['String'];
+  /** Course subject, e.g. SENG, CSC */
+  subject: Scalars['String'];
+  /** Term course is offered in */
+  term: Term;
+  /** Course title. e.g. Introduction to Artificial Intelligence */
+  title: Scalars['String'];
+};
+
 export type CreateTeachingPreferenceInput = {
   courses: Array<CoursePreferenceInput>;
   hasRelief: Scalars['Boolean'];
@@ -137,7 +152,7 @@ export enum Day {
   Sunday = 'SUNDAY',
   Thursday = 'THURSDAY',
   Tuesday = 'TUESDAY',
-  Wednesday = 'WEDNESDAY',
+  Wednesday = 'WEDNESDAY'
 }
 
 export type EditCourseInput = {
@@ -189,7 +204,10 @@ export type Mutation = {
   createTeachingPreference: Response;
   /** Register a new user account */
   createUser: CreateUserMutationResult;
-  /** Edit schedule and Plug and Play Compnay 3's and 4's Algorithms */
+  /**
+   * Edit schedule and Plug and Play Compnay 3's and 4's Algorithms
+   * @deprecated Use updateSchedule instead
+   */
   editCourse: Response;
   /** Generate schedule */
   generateSchedule: Response;
@@ -199,38 +217,53 @@ export type Mutation = {
   logout: AuthPayload;
   /** Reset a users password. */
   resetPassword: ResetPasswordMutationResult;
+  /** Update an entire schdule. */
+  updateSchedule: UpdateScheduleResponse;
   /** Updates a user given the user id. */
   updateUser?: Maybe<UpdateUserMutationResult>;
 };
+
 
 export type MutationChangeUserPasswordArgs = {
   input: ChangeUserPasswordInput;
 };
 
+
 export type MutationCreateTeachingPreferenceArgs = {
   input: CreateTeachingPreferenceInput;
 };
+
 
 export type MutationCreateUserArgs = {
   username: Scalars['String'];
 };
 
+
 export type MutationEditCourseArgs = {
   input?: InputMaybe<EditCourseInput>;
 };
 
+
 export type MutationGenerateScheduleArgs = {
   input: GenerateScheduleInput;
 };
+
 
 export type MutationLoginArgs = {
   password: Scalars['String'];
   username: Scalars['String'];
 };
 
+
 export type MutationResetPasswordArgs = {
   id: Scalars['ID'];
 };
+
+
+export type MutationUpdateScheduleArgs = {
+  input: UpdateScheduleInput;
+};
+
 
 export type MutationUpdateUserArgs = {
   input: UpdateUserInput;
@@ -254,13 +287,16 @@ export type Query = {
   survey: TeachingPreferenceSurvey;
 };
 
+
 export type QueryCoursesArgs = {
   term?: InputMaybe<Term>;
 };
 
+
 export type QueryFindUserByIdArgs = {
   id: Scalars['ID'];
 };
+
 
 export type QueryScheduleArgs = {
   year?: InputMaybe<Scalars['Int']>;
@@ -287,7 +323,7 @@ export enum Role {
   /** Administrator role (department staff etc.) */
   Admin = 'ADMIN',
   /** User role (professor, student etc.) */
-  User = 'USER',
+  User = 'USER'
 }
 
 /** Generated schedule for a year */
@@ -303,6 +339,7 @@ export type Schedule = {
   year: Scalars['Int'];
 };
 
+
 /** Generated schedule for a year */
 export type ScheduleCoursesArgs = {
   term: Term;
@@ -317,8 +354,29 @@ export type TeachingPreferenceSurvey = {
 export enum Term {
   Fall = 'FALL',
   Spring = 'SPRING',
-  Summer = 'SUMMER',
+  Summer = 'SUMMER'
 }
+
+export type UpdateScheduleInput = {
+  /** The updated courses */
+  courses: Array<CourseSectionInput>;
+  /** ID of the schedule to update. If not given, the current schedule will be updated. */
+  id?: InputMaybe<Scalars['ID']>;
+  /** Whether to perform validation on the backend through algorithm 1. */
+  skipValidation: Scalars['Boolean'];
+  /** Which algorithm to use. If COMPANY4 is selected then validation will not be performed regardless of skipValidation. */
+  validation: Company;
+};
+
+export type UpdateScheduleResponse = {
+  __typename?: 'UpdateScheduleResponse';
+  /** Errors associated to updating the schedule. Only populated if success is false. This could include validation issues. */
+  errors?: Maybe<Array<Scalars['String']>>;
+  /** General messaging for the client to consume. */
+  message?: Maybe<Scalars['String']>;
+  /** Whether the update was successful */
+  success: Scalars['Boolean'];
+};
 
 export type UpdateUserInput = {
   /** ID of user to update */
@@ -351,14 +409,15 @@ export type User = {
   username: Scalars['String'];
 };
 
+
+
 export type ResolverTypeWrapper<T> = Promise<T> | T;
+
 
 export type ResolverWithResolve<TResult, TParent, TContext, TArgs> = {
   resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
 };
-export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
-  | ResolverFn<TResult, TParent, TContext, TArgs>
-  | ResolverWithResolve<TResult, TParent, TContext, TArgs>;
+export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> = ResolverFn<TResult, TParent, TContext, TArgs> | ResolverWithResolve<TResult, TParent, TContext, TArgs>;
 
 export type ResolverFn<TResult, TParent, TContext, TArgs> = (
   parent: TParent,
@@ -381,25 +440,9 @@ export type SubscriptionResolveFn<TResult, TParent, TContext, TArgs> = (
   info: GraphQLResolveInfo
 ) => TResult | Promise<TResult>;
 
-export interface SubscriptionSubscriberObject<
-  TResult,
-  TKey extends string,
-  TParent,
-  TContext,
-  TArgs
-> {
-  subscribe: SubscriptionSubscribeFn<
-    { [key in TKey]: TResult },
-    TParent,
-    TContext,
-    TArgs
-  >;
-  resolve?: SubscriptionResolveFn<
-    TResult,
-    { [key in TKey]: TResult },
-    TContext,
-    TArgs
-  >;
+export interface SubscriptionSubscriberObject<TResult, TKey extends string, TParent, TContext, TArgs> {
+  subscribe: SubscriptionSubscribeFn<{ [key in TKey]: TResult }, TParent, TContext, TArgs>;
+  resolve?: SubscriptionResolveFn<TResult, { [key in TKey]: TResult }, TContext, TArgs>;
 }
 
 export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
@@ -407,26 +450,12 @@ export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
   resolve: SubscriptionResolveFn<TResult, any, TContext, TArgs>;
 }
 
-export type SubscriptionObject<
-  TResult,
-  TKey extends string,
-  TParent,
-  TContext,
-  TArgs
-> =
+export type SubscriptionObject<TResult, TKey extends string, TParent, TContext, TArgs> =
   | SubscriptionSubscriberObject<TResult, TKey, TParent, TContext, TArgs>
   | SubscriptionResolverObject<TResult, TParent, TContext, TArgs>;
 
-export type SubscriptionResolver<
-  TResult,
-  TKey extends string,
-  TParent = {},
-  TContext = {},
-  TArgs = {}
-> =
-  | ((
-      ...args: any[]
-    ) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
+export type SubscriptionResolver<TResult, TKey extends string, TParent = {}, TContext = {}, TArgs = {}> =
+  | ((...args: any[]) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
   | SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>;
 
 export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
@@ -435,20 +464,11 @@ export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
   info: GraphQLResolveInfo
 ) => Maybe<TTypes> | Promise<Maybe<TTypes>>;
 
-export type IsTypeOfResolverFn<T = {}, TContext = {}> = (
-  obj: T,
-  context: TContext,
-  info: GraphQLResolveInfo
-) => boolean | Promise<boolean>;
+export type IsTypeOfResolverFn<T = {}, TContext = {}> = (obj: T, context: TContext, info: GraphQLResolveInfo) => boolean | Promise<boolean>;
 
 export type NextResolverFn<T> = () => Promise<T>;
 
-export type DirectiveResolverFn<
-  TResult = {},
-  TParent = {},
-  TContext = {},
-  TArgs = {}
-> = (
+export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs = {}> = (
   next: NextResolverFn<TResult>,
   parent: TParent,
   args: TArgs,
@@ -467,6 +487,8 @@ export type ResolversTypes = {
   CoursePreference: ResolverTypeWrapper<CoursePreference>;
   CoursePreferenceInput: CoursePreferenceInput;
   CourseSection: ResolverTypeWrapper<CourseSection>;
+  CourseSectionInput: CourseSectionInput;
+  CourseUpdateInput: CourseUpdateInput;
   CreateTeachingPreferenceInput: CreateTeachingPreferenceInput;
   CreateUserMutationResult: ResolverTypeWrapper<CreateUserMutationResult>;
   Date: ResolverTypeWrapper<Scalars['Date']>;
@@ -488,6 +510,8 @@ export type ResolversTypes = {
   String: ResolverTypeWrapper<Scalars['String']>;
   TeachingPreferenceSurvey: ResolverTypeWrapper<TeachingPreferenceSurvey>;
   Term: Term;
+  UpdateScheduleInput: UpdateScheduleInput;
+  UpdateScheduleResponse: ResolverTypeWrapper<UpdateScheduleResponse>;
   UpdateUserInput: UpdateUserInput;
   UpdateUserMutationResult: ResolverTypeWrapper<UpdateUserMutationResult>;
   User: ResolverTypeWrapper<User>;
@@ -503,6 +527,8 @@ export type ResolversParentTypes = {
   CoursePreference: CoursePreference;
   CoursePreferenceInput: CoursePreferenceInput;
   CourseSection: CourseSection;
+  CourseSectionInput: CourseSectionInput;
+  CourseUpdateInput: CourseUpdateInput;
   CreateTeachingPreferenceInput: CreateTeachingPreferenceInput;
   CreateUserMutationResult: CreateUserMutationResult;
   Date: Scalars['Date'];
@@ -521,25 +547,21 @@ export type ResolversParentTypes = {
   Schedule: Schedule;
   String: Scalars['String'];
   TeachingPreferenceSurvey: TeachingPreferenceSurvey;
+  UpdateScheduleInput: UpdateScheduleInput;
+  UpdateScheduleResponse: UpdateScheduleResponse;
   UpdateUserInput: UpdateUserInput;
   UpdateUserMutationResult: UpdateUserMutationResult;
   User: User;
 };
 
-export type AuthPayloadResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['AuthPayload'] = ResolversParentTypes['AuthPayload']
-> = {
+export type AuthPayloadResolvers<ContextType = any, ParentType extends ResolversParentTypes['AuthPayload'] = ResolversParentTypes['AuthPayload']> = {
   message?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   token?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type CourseIdResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['CourseID'] = ResolversParentTypes['CourseID']
-> = {
+export type CourseIdResolvers<ContextType = any, ParentType extends ResolversParentTypes['CourseID'] = ResolversParentTypes['CourseID']> = {
   code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   subject?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   term?: Resolver<ResolversTypes['Term'], ParentType, ContextType>;
@@ -547,46 +569,25 @@ export type CourseIdResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type CoursePreferenceResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['CoursePreference'] = ResolversParentTypes['CoursePreference']
-> = {
+export type CoursePreferenceResolvers<ContextType = any, ParentType extends ResolversParentTypes['CoursePreference'] = ResolversParentTypes['CoursePreference']> = {
   id?: Resolver<ResolversTypes['CourseID'], ParentType, ContextType>;
   preference?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type CourseSectionResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['CourseSection'] = ResolversParentTypes['CourseSection']
-> = {
+export type CourseSectionResolvers<ContextType = any, ParentType extends ResolversParentTypes['CourseSection'] = ResolversParentTypes['CourseSection']> = {
   CourseID?: Resolver<ResolversTypes['CourseID'], ParentType, ContextType>;
   capacity?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   endDate?: Resolver<ResolversTypes['Date'], ParentType, ContextType>;
   hoursPerWeek?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
-  meetingTimes?: Resolver<
-    Array<ResolversTypes['MeetingTime']>,
-    ParentType,
-    ContextType
-  >;
-  professors?: Resolver<
-    Maybe<Array<ResolversTypes['User']>>,
-    ParentType,
-    ContextType
-  >;
-  sectionNumber?: Resolver<
-    Maybe<ResolversTypes['String']>,
-    ParentType,
-    ContextType
-  >;
+  meetingTimes?: Resolver<Array<ResolversTypes['MeetingTime']>, ParentType, ContextType>;
+  professors?: Resolver<Maybe<Array<ResolversTypes['User']>>, ParentType, ContextType>;
+  sectionNumber?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   startDate?: Resolver<ResolversTypes['Date'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type CreateUserMutationResultResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['CreateUserMutationResult'] = ResolversParentTypes['CreateUserMutationResult']
-> = {
+export type CreateUserMutationResultResolvers<ContextType = any, ParentType extends ResolversParentTypes['CreateUserMutationResult'] = ResolversParentTypes['CreateUserMutationResult']> = {
   message?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   password?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
@@ -594,207 +595,92 @@ export type CreateUserMutationResultResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export interface DateScalarConfig
-  extends GraphQLScalarTypeConfig<ResolversTypes['Date'], any> {
+export interface DateScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['Date'], any> {
   name: 'Date';
 }
 
-export type ErrorResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Error'] = ResolversParentTypes['Error']
-> = {
-  errors?: Resolver<
-    Maybe<Array<ResolversTypes['Error']>>,
-    ParentType,
-    ContextType
-  >;
+export type ErrorResolvers<ContextType = any, ParentType extends ResolversParentTypes['Error'] = ResolversParentTypes['Error']> = {
+  errors?: Resolver<Maybe<Array<ResolversTypes['Error']>>, ParentType, ContextType>;
   message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type MeetingTimeResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['MeetingTime'] = ResolversParentTypes['MeetingTime']
-> = {
+export type MeetingTimeResolvers<ContextType = any, ParentType extends ResolversParentTypes['MeetingTime'] = ResolversParentTypes['MeetingTime']> = {
   day?: Resolver<ResolversTypes['Day'], ParentType, ContextType>;
   endTime?: Resolver<ResolversTypes['Date'], ParentType, ContextType>;
   startTime?: Resolver<ResolversTypes['Date'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type MutationResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']
-> = {
-  changeUserPassword?: Resolver<
-    ResolversTypes['Response'],
-    ParentType,
-    ContextType,
-    RequireFields<MutationChangeUserPasswordArgs, 'input'>
-  >;
-  createTeachingPreference?: Resolver<
-    ResolversTypes['Response'],
-    ParentType,
-    ContextType,
-    RequireFields<MutationCreateTeachingPreferenceArgs, 'input'>
-  >;
-  createUser?: Resolver<
-    ResolversTypes['CreateUserMutationResult'],
-    ParentType,
-    ContextType,
-    RequireFields<MutationCreateUserArgs, 'username'>
-  >;
-  editCourse?: Resolver<
-    ResolversTypes['Response'],
-    ParentType,
-    ContextType,
-    Partial<MutationEditCourseArgs>
-  >;
-  generateSchedule?: Resolver<
-    ResolversTypes['Response'],
-    ParentType,
-    ContextType,
-    RequireFields<MutationGenerateScheduleArgs, 'input'>
-  >;
-  login?: Resolver<
-    ResolversTypes['AuthPayload'],
-    ParentType,
-    ContextType,
-    RequireFields<MutationLoginArgs, 'password' | 'username'>
-  >;
+export type MutationResolvers<ContextType = any, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = {
+  changeUserPassword?: Resolver<ResolversTypes['Response'], ParentType, ContextType, RequireFields<MutationChangeUserPasswordArgs, 'input'>>;
+  createTeachingPreference?: Resolver<ResolversTypes['Response'], ParentType, ContextType, RequireFields<MutationCreateTeachingPreferenceArgs, 'input'>>;
+  createUser?: Resolver<ResolversTypes['CreateUserMutationResult'], ParentType, ContextType, RequireFields<MutationCreateUserArgs, 'username'>>;
+  editCourse?: Resolver<ResolversTypes['Response'], ParentType, ContextType, Partial<MutationEditCourseArgs>>;
+  generateSchedule?: Resolver<ResolversTypes['Response'], ParentType, ContextType, RequireFields<MutationGenerateScheduleArgs, 'input'>>;
+  login?: Resolver<ResolversTypes['AuthPayload'], ParentType, ContextType, RequireFields<MutationLoginArgs, 'password' | 'username'>>;
   logout?: Resolver<ResolversTypes['AuthPayload'], ParentType, ContextType>;
-  resetPassword?: Resolver<
-    ResolversTypes['ResetPasswordMutationResult'],
-    ParentType,
-    ContextType,
-    RequireFields<MutationResetPasswordArgs, 'id'>
-  >;
-  updateUser?: Resolver<
-    Maybe<ResolversTypes['UpdateUserMutationResult']>,
-    ParentType,
-    ContextType,
-    RequireFields<MutationUpdateUserArgs, 'input'>
-  >;
+  resetPassword?: Resolver<ResolversTypes['ResetPasswordMutationResult'], ParentType, ContextType, RequireFields<MutationResetPasswordArgs, 'id'>>;
+  updateSchedule?: Resolver<ResolversTypes['UpdateScheduleResponse'], ParentType, ContextType, RequireFields<MutationUpdateScheduleArgs, 'input'>>;
+  updateUser?: Resolver<Maybe<ResolversTypes['UpdateUserMutationResult']>, ParentType, ContextType, RequireFields<MutationUpdateUserArgs, 'input'>>;
 };
 
-export type QueryResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']
-> = {
-  allUsers?: Resolver<
-    Maybe<Array<ResolversTypes['User']>>,
-    ParentType,
-    ContextType
-  >;
-  coursePreferences?: Resolver<
-    Maybe<Array<ResolversTypes['CoursePreference']>>,
-    ParentType,
-    ContextType
-  >;
-  courses?: Resolver<
-    Maybe<Array<ResolversTypes['CourseSection']>>,
-    ParentType,
-    ContextType,
-    Partial<QueryCoursesArgs>
-  >;
-  findUserById?: Resolver<
-    Maybe<ResolversTypes['User']>,
-    ParentType,
-    ContextType,
-    RequireFields<QueryFindUserByIdArgs, 'id'>
-  >;
+export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
+  allUsers?: Resolver<Maybe<Array<ResolversTypes['User']>>, ParentType, ContextType>;
+  coursePreferences?: Resolver<Maybe<Array<ResolversTypes['CoursePreference']>>, ParentType, ContextType>;
+  courses?: Resolver<Maybe<Array<ResolversTypes['CourseSection']>>, ParentType, ContextType, Partial<QueryCoursesArgs>>;
+  findUserById?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<QueryFindUserByIdArgs, 'id'>>;
   me?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
-  schedule?: Resolver<
-    Maybe<ResolversTypes['Schedule']>,
-    ParentType,
-    ContextType,
-    Partial<QueryScheduleArgs>
-  >;
-  survey?: Resolver<
-    ResolversTypes['TeachingPreferenceSurvey'],
-    ParentType,
-    ContextType
-  >;
+  schedule?: Resolver<Maybe<ResolversTypes['Schedule']>, ParentType, ContextType, Partial<QueryScheduleArgs>>;
+  survey?: Resolver<ResolversTypes['TeachingPreferenceSurvey'], ParentType, ContextType>;
 };
 
-export type ResetPasswordMutationResultResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['ResetPasswordMutationResult'] = ResolversParentTypes['ResetPasswordMutationResult']
-> = {
+export type ResetPasswordMutationResultResolvers<ContextType = any, ParentType extends ResolversParentTypes['ResetPasswordMutationResult'] = ResolversParentTypes['ResetPasswordMutationResult']> = {
   message?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   password?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type ResponseResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Response'] = ResolversParentTypes['Response']
-> = {
+export type ResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['Response'] = ResolversParentTypes['Response']> = {
   message?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type ScheduleResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Schedule'] = ResolversParentTypes['Schedule']
-> = {
-  courses?: Resolver<
-    Maybe<Array<ResolversTypes['CourseSection']>>,
-    ParentType,
-    ContextType,
-    RequireFields<ScheduleCoursesArgs, 'term'>
-  >;
+export type ScheduleResolvers<ContextType = any, ParentType extends ResolversParentTypes['Schedule'] = ResolversParentTypes['Schedule']> = {
+  courses?: Resolver<Maybe<Array<ResolversTypes['CourseSection']>>, ParentType, ContextType, RequireFields<ScheduleCoursesArgs, 'term'>>;
   createdAt?: Resolver<ResolversTypes['Date'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   year?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type TeachingPreferenceSurveyResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['TeachingPreferenceSurvey'] = ResolversParentTypes['TeachingPreferenceSurvey']
-> = {
-  courses?: Resolver<
-    Array<ResolversTypes['CourseID']>,
-    ParentType,
-    ContextType
-  >;
+export type TeachingPreferenceSurveyResolvers<ContextType = any, ParentType extends ResolversParentTypes['TeachingPreferenceSurvey'] = ResolversParentTypes['TeachingPreferenceSurvey']> = {
+  courses?: Resolver<Array<ResolversTypes['CourseID']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type UpdateUserMutationResultResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['UpdateUserMutationResult'] = ResolversParentTypes['UpdateUserMutationResult']
-> = {
-  errors?: Resolver<
-    Maybe<Array<ResolversTypes['Error']>>,
-    ParentType,
-    ContextType
-  >;
+export type UpdateScheduleResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['UpdateScheduleResponse'] = ResolversParentTypes['UpdateScheduleResponse']> = {
+  errors?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
+  message?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type UpdateUserMutationResultResolvers<ContextType = any, ParentType extends ResolversParentTypes['UpdateUserMutationResult'] = ResolversParentTypes['UpdateUserMutationResult']> = {
+  errors?: Resolver<Maybe<Array<ResolversTypes['Error']>>, ParentType, ContextType>;
   user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type UserResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User']
-> = {
+export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User']> = {
   active?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  displayName?: Resolver<
-    Maybe<ResolversTypes['String']>,
-    ParentType,
-    ContextType
-  >;
+  displayName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   hasPeng?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   password?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  preferences?: Resolver<
-    Maybe<Array<ResolversTypes['CoursePreference']>>,
-    ParentType,
-    ContextType
-  >;
+  preferences?: Resolver<Maybe<Array<ResolversTypes['CoursePreference']>>, ParentType, ContextType>;
   role?: Resolver<ResolversTypes['Role'], ParentType, ContextType>;
   username?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
@@ -815,6 +701,8 @@ export type Resolvers<ContextType = any> = {
   Response?: ResponseResolvers<ContextType>;
   Schedule?: ScheduleResolvers<ContextType>;
   TeachingPreferenceSurvey?: TeachingPreferenceSurveyResolvers<ContextType>;
+  UpdateScheduleResponse?: UpdateScheduleResponseResolvers<ContextType>;
   UpdateUserMutationResult?: UpdateUserMutationResultResolvers<ContextType>;
   User?: UserResolvers<ContextType>;
 };
+

--- a/src/schema/schema.graphql
+++ b/src/schema/schema.graphql
@@ -90,6 +90,11 @@ type Mutation {
   Edit schedule and Plug and Play Compnay 3's and 4's Algorithms
   """
   editCourse(input: EditCourseInput): Response!
+    @deprecated(reason: "Use updateSchedule instead")
+  """
+  Update an entire schdule.
+  """
+  updateSchedule(input: UpdateScheduleInput!): UpdateScheduleResponse!
 }
 
 type Response {
@@ -180,6 +185,94 @@ input CourseInput {
   Number of Sections for a course
   """
   section: Int!
+}
+
+input UpdateScheduleInput {
+  """
+  ID of the schedule to update. If not given, the current schedule will be updated.
+  """
+  id: ID
+  """
+  The updated courses
+  """
+  courses: [CourseSectionInput!]!
+  """
+  Whether to perform validation on the backend through algorithm 1.
+  """
+  skipValidation: Boolean!
+  """
+  Which algorithm to use. If COMPANY4 is selected then validation will not be performed regardless of skipValidation.
+  """
+  validation: Company!
+}
+
+input CourseSectionInput {
+  """
+  The course identifier
+  """
+  id: CourseUpdateInput!
+  """
+  How many hours per week a course takes
+  """
+  hoursPerWeek: Float!
+  """
+  Maximum capacity of the section
+  """
+  capacity: Int!
+  """
+  Section number for courses, eg: A01, A02
+  """
+  sectionNumber: String
+  """
+  Professor's info, if any professors are assigned. Usernames
+  """
+  professors: [String!]!
+  """
+  The start date of the course
+  """
+  startDate: Date!
+  """
+  The end date of the course
+  """
+  endDate: Date!
+  """
+  Days of the week the class is offered in - see Day
+  """
+  meetingTimes: [MeetingTimeInput!]!
+}
+
+input CourseUpdateInput {
+  """
+  Course subject, e.g. SENG, CSC
+  """
+  subject: String!
+  """
+  Course title. e.g. Introduction to Artificial Intelligence
+  """
+  title: String!
+  """
+  Course code, e.g. 499, 310
+  """
+  code: String!
+  """
+  Term course is offered in
+  """
+  term: Term!
+}
+
+type UpdateScheduleResponse {
+  """
+  Whether the update was successful
+  """
+  success: Boolean!
+  """
+  General messaging for the client to consume.
+  """
+  message: String
+  """
+  Errors associated to updating the schedule. Only populated if success is false. This could include validation issues.
+  """
+  errors: [String!]
 }
 
 type CourseID {


### PR DESCRIPTION
- Added the following fields to GraphQL schema to match the shared repo changes
 1) updateSchedule, 
 2) UpdateScheduleInput, 
 3) CourseSectionInput, 
 4) CourseUpdateInput, 
 5) UpdateScheduleResponse

-Generated new graphql.ts file to match changes made to schema
-Depreciated edit course to match shared repo changes
-Changed "npm run codegen" destination folder to replace previous graphql.ts file instead of generating into the root folder