### PR TITLE
feat: prisma db reset workflow

### DIFF
--- a/.github/workflows/db.yml
+++ b/.github/workflows/db.yml
@@ -16,4 +16,4 @@ jobs:
       - name: Code Linting
         run: npx -y prisma migrate reset
         env: 
-          DATABASE_URL: ${{ secrets.DATABSE_URL }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}

--- a/.github/workflows/db.yml
+++ b/.github/workflows/db.yml
@@ -1,0 +1,19 @@
+name: Prisma Migrate Reset
+on:
+  workflow_dispatch:
+jobs:
+  reset:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci --no-audit --no-progress --no-optional
+      - name: Code Linting
+        run: npx -y prisma migrate reset
+        env: 
+          DATABASE_URL: ${{ secrets.DATABSE_URL }}

--- a/src/utils/seedingFunctions.ts
+++ b/src/utils/seedingFunctions.ts
@@ -11,19 +11,18 @@ const prisma = new PrismaClient();
  * @param professor a professor object
  */
 
+const pwsalt = bcrypt.genSaltSync(10);
+const pwhash = bcrypt.hashSync('testpassword', pwsalt);
+
 export async function addTeachingAndCoursePreferences(professor: any) {
-  const firstName = professor.displayName.split(', ')[1];
-  const lastName = professor.displayName.split(', ')[0];
+  const [lastName, firstName] = professor.displayName.split(', ');
 
-  const generatedUsername = `${firstName}${lastName}`;
-
-  const pwsalt = bcrypt.genSaltSync(10);
-  const pwhash = bcrypt.hashSync('testpassword', pwsalt);
+  const username = `${firstName}${lastName}`.toLowerCase().replace(/\s/g, '');
 
   // Create professor user if not created
   let currentProf = await prisma.user.findFirst({
     where: {
-      username: generatedUsername,
+      username: username,
     },
   });
 
@@ -33,7 +32,7 @@ export async function addTeachingAndCoursePreferences(professor: any) {
         active: true,
         hasPeng: true,
         password: pwhash,
-        username: generatedUsername,
+        username: username,
         displayName: `${firstName} ${lastName}`,
         role: Role.USER,
       },


### PR DESCRIPTION
Implements a simple workflow to allow resetting the db by any user that has write access to the repo.
The Postgres credentials are loaded in as secrets already.