### PR TITLE
feat: save term course prefs from CreateTeachingPreferenceInput

### DIFF
--- a/prisma/migrations/20220718223833_course_prefs_numbers/migration.sql
+++ b/prisma/migrations/20220718223833_course_prefs_numbers/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "TeachingPreference" ADD COLUMN     "fallTermCourses" INTEGER NOT NULL DEFAULT 1,
+ADD COLUMN     "springTermCourses" INTEGER NOT NULL DEFAULT 1,
+ADD COLUMN     "summerTermCourses" INTEGER NOT NULL DEFAULT 1;

--- a/prisma/migrations/20220718223833_course_prefs_numbers/migration.sql
+++ b/prisma/migrations/20220718223833_course_prefs_numbers/migration.sql
@@ -1,4 +1,4 @@
 -- AlterTable
-ALTER TABLE "TeachingPreference" ADD COLUMN     "fallTermCourses" INTEGER NOT NULL DEFAULT 1,
-ADD COLUMN     "springTermCourses" INTEGER NOT NULL DEFAULT 1,
-ADD COLUMN     "summerTermCourses" INTEGER NOT NULL DEFAULT 1;
+ALTER TABLE "TeachingPreference" ADD COLUMN     "fallTermCourses" INTEGER NOT NULL DEFAULT 2,
+ADD COLUMN     "springTermCourses" INTEGER NOT NULL DEFAULT 2,
+ADD COLUMN     "summerTermCourses" INTEGER NOT NULL DEFAULT 2;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -72,6 +72,9 @@ model TeachingPreference {
   studyLeaveReason   String?
   topicsOrGradCourse Boolean
   topicDescription   String?
+  fallTermCourses    Int                @default(1)
+  springTermCourses  Int                @default(1)
+  summerTermCourses  Int                @default(1)
   User               User?              @relation(fields: [userId], references: [id])
   userId             Int?               @unique
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -72,9 +72,9 @@ model TeachingPreference {
   studyLeaveReason   String?
   topicsOrGradCourse Boolean
   topicDescription   String?
-  fallTermCourses    Int                @default(1)
-  springTermCourses  Int                @default(1)
-  summerTermCourses  Int                @default(1)
+  fallTermCourses    Int                @default(2)
+  springTermCourses  Int                @default(2)
+  summerTermCourses  Int                @default(2)
   User               User?              @relation(fields: [userId], references: [id])
   userId             Int?               @unique
 

--- a/src/prisma/user.ts
+++ b/src/prisma/user.ts
@@ -77,9 +77,9 @@ async function updateUserSurvey(
     reliefReason: input.reliefReason,
     studyLeave: false,
     topicsOrGradCourse: input.hasTopic,
-    fallTermCourses: input.fallTermCourses ?? 1,
-    springTermCourses: input.springTermCourses ?? 1,
-    summerTermCourses: input.summerTermCourses ?? 1,
+    fallTermCourses: input.fallTermCourses ?? 2,
+    springTermCourses: input.springTermCourses ?? 2,
+    summerTermCourses: input.summerTermCourses ?? 2,
   };
 
   await prisma.user.update({

--- a/src/prisma/user.ts
+++ b/src/prisma/user.ts
@@ -77,6 +77,9 @@ async function updateUserSurvey(
     reliefReason: input.reliefReason,
     studyLeave: false,
     topicsOrGradCourse: input.hasTopic,
+    fallTermCourses: input.fallTermCourses ?? 1,
+    springTermCourses: input.springTermCourses ?? 1,
+    summerTermCourses: input.summerTermCourses ?? 1,
   };
 
   await prisma.user.update({


### PR DESCRIPTION
Implements the updated schema to take in preference for how many courses to teach for a given term. Updates the database and uses a default value of 1 if not provided.
Closes #121 