### PR TITLE
fix: seperate default pref env values and make generic env parser

### DIFF
--- a/src/resolvers/resolverUtils.ts
+++ b/src/resolvers/resolverUtils.ts
@@ -38,9 +38,10 @@ import {
   CourseSectionInput,
   UpdateScheduleInput,
 } from '../schema';
-import { CourseType, getSeqNumber, prefValue } from '../utils';
+import { CourseType, getSeqNumber, getEnvValue } from '../utils';
 
-const DEFAULT_NUM_COURSES = prefValue();
+const DEFAULT_NUM_COURSES = getEnvValue('DEFAULT_NUM_COURSES', 2);
+const DEFAULT_PREF = getEnvValue('DEFAULT_PREF', 3);
 const DEFAULT_SUBJECT_COURSES = ['CSC', 'SENG', 'ECE'];
 
 const isFacultyCourse = (subject: string): boolean =>
@@ -473,7 +474,7 @@ export async function prepareProfPrefs() {
       preferenceNum:
         userPrefs.get(`${subject}${courseCode}-${term}`) ??
         (isFacultyCourse(subject)
-          ? DEFAULT_NUM_COURSES // if the subject is in the default subjects list, use the default pref (ie. inside of the faculty)
+          ? DEFAULT_PREF // if the subject is in the default subjects list, use the default pref (ie. inside of the faculty)
           : 0), // otherwise, use 0 (ie. outside of the faculty)
       term,
     }));

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -8,8 +8,6 @@ import {
 import { getISOTime, getMeetingDays } from './time';
 const isAdmin = (user: FullUser) => user.role === Role.ADMIN;
 
-const defaultPref = 2;
-
 export {
   getISOTime,
   isAdmin,
@@ -27,13 +25,14 @@ const appendDay = (isDay: boolean, day: Day, days: Day[]): Day[] => {
   return days;
 };
 
-export function prefValue(): number {
-  const p = process.env.DEFAULT_PREF;
-  if (!p) return defaultPref;
+export function getEnvValue(key: string, defaultValue: number): number {
+  const value = process.env[key];
+  if (!value) return defaultValue;
   try {
-    return parseInt(p, 10);
+    return parseInt(value, 10);
   } catch (e) {
-    return defaultPref;
+    console.error(`Failed to parse ${key} as number ${value}`);
+    return defaultValue;
   }
 }
 


### PR DESCRIPTION
Fixes where the `DEFAULT_PREF` value was not being used in the right place (the default preference for a course when a prof has not filled out the survey.

`DEFAULT_PREF` is the default preference value for a engineering faculty course when a prof has not filled out the survey.
`DEFAULT_NUM_COURSES` is the default preference value for how many courses a prof wishes to teach in a given semester when they have no filled out the teaching survey.